### PR TITLE
add oracle cloud configuration guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
 一般留空即可。
 
 > 若确认过其他配置正确又不能访问，请在服务商的文档中查看并填写英文的 Region，例如 `cn-east-1`。
+> 
+> Cloudflare 需要填写均为小写字母的 `auto`。
 
 ## 部分对象存储服务商兼容性
 
@@ -55,10 +57,12 @@
 |金山云|https://docs.ksyun.com/documents/6761|Virtual Hosted Style|✅|
 |青云|https://docsv3.qingcloud.com/storage/object-storage/s3/intro/|Virtual Hosted Style / <br>Path Style|✅|
 |网易数帆|[https://sf.163.com/help/documents/89796157866430464](https://sf.163.com/help/documents/89796157866430464)|Virtual Hosted Style|✅|
+|Cloudflare|Cloudflare S3 兼容性API<br>[https://developers.cloudflare.com/r2/data-access/s3-api/](https://developers.cloudflare.com/r2/data-access/s3-api/)|Virtual Hosted Style / <br>Path Style|✅|
+| Oracle Cloud |[https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm)|Virtual Hosted Style / <br>Path Style|✅|
 |自建minio|\-|Path Style|✅|
 |华为云|文档未说明是否兼容，工单反馈不保证兼容性，实际测试可以使用|Virtual Hosted Style|❓|
-|Ucloud|只支持 8MB 大小的分片，本插件暂不支持<br>[https://docs.ucloud.cn/ufile/s3/s3\_introduction](https://docs.ucloud.cn/ufile/s3/s3_introduction)|\-|❎|
-|又拍云|暂不支持 s3 协议|\-|❎|
+|Ucloud|只支持 8MB 大小的分片，本插件暂不支持<br>[https://docs.ucloud.cn/ufile/s3/s3\_introduction](https://docs.ucloud.cn/ufile/s3/s3_introduction)|\-|❌|
+|又拍云|暂不支持 s3 协议|\-|❌|
 
 ## 开发环境
 


### PR DESCRIPTION
增加oracle cloud的配置，实测可以上传。
官方文档地址：https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm

`Path Style`和`Virtual Hosted Style`均可以配置，并测试成功。
推荐使用`Virtual Hosted Style`方式：

![image](https://user-images.githubusercontent.com/19516717/216295351-5146f5ab-0cf6-43a1-bc6e-ad261c55f198.png)

entrypoint: compat.objectstorage.{region}.oraclecloud.com
将`{region}`替换为上图中`区域`的值

绑定域名留空

![image](https://user-images.githubusercontent.com/19516717/216307619-b54b5829-8341-469d-86b1-dad7e1e65260.png)
`Access Key`和`Access Secret` 在用户设置里面生成`客户秘钥`

```release-note
None
```