### PR TITLE
Fix incorrect setting on TTL of share URL

### DIFF
--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -120,7 +120,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
                         .key(objectKey)
                         .build();
                     var presignedRequest = GetObjectPresignRequest.builder()
-                        .signatureDuration(Duration.ofMinutes(5))
+                        .signatureDuration(ttl)
                         .getObjectRequest(getObjectRequest)
                         .build();
                     var presignedGetObjectRequest = s3Presigner.presignGetObject(presignedRequest);
@@ -170,9 +170,9 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
 
         var metadata = new Metadata();
         metadata.setName(UUID.randomUUID().toString());
-        metadata.setAnnotations(
+        metadata.setAnnotations(new HashMap<>(
             Map.of(OBJECT_KEY, objectDetail.uploadState.objectKey, Constant.EXTERNAL_LINK_ANNO_KEY,
-                UriUtils.encodePath(externalLink, StandardCharsets.UTF_8)));
+                UriUtils.encodePath(externalLink, StandardCharsets.UTF_8))));
 
         var objectMetadata = objectDetail.objectMetadata();
         var spec = new AttachmentSpec();


### PR DESCRIPTION
Share URL mechanism was provided in https://github.com/halo-sigs/plugin-s3/pull/35, and I set the TTL of the URL with 5 mins incorrectly.

```release-note
None
```