### PR TITLE
Ensure non-trailing parts are of equal size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     testImplementation 'run.halo.app:api'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
 }
 
 test {

--- a/src/test/java/run/halo/s3os/S3OsAttachmentHandlerTest.java
+++ b/src/test/java/run/halo/s3os/S3OsAttachmentHandlerTest.java
@@ -1,12 +1,19 @@
 package run.halo.s3os;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 import run.halo.app.core.extension.attachment.Policy;
 
 class S3OsAttachmentHandlerTest {
@@ -32,5 +39,58 @@ class S3OsAttachmentHandlerTest {
 
         // policy is null
         assertFalse(handler.shouldHandle(null));
+    }
+
+    @Test
+    void reshapeDataBufferWithSmallerBufferSize() {
+        var handler = new S3OsAttachmentHandler();
+        var factory = DefaultDataBufferFactory.sharedInstance;
+        var content = Flux.<DataBuffer>fromIterable(List.of(factory.wrap("halo".getBytes())));
+
+        StepVerifier.create(handler.reshape(content, 2))
+            .assertNext(dataBuffer -> {
+                var str = dataBuffer.toString(UTF_8);
+                assertEquals("ha", str);
+            })
+            .assertNext(dataBuffer -> {
+                var str = dataBuffer.toString(UTF_8);
+                assertEquals("lo", str);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    void reshapeDataBufferWithBiggerBufferSize() {
+        var handler = new S3OsAttachmentHandler();
+        var factory = DefaultDataBufferFactory.sharedInstance;
+        var content = Flux.<DataBuffer>fromIterable(List.of(factory.wrap("halo".getBytes())));
+
+        StepVerifier.create(handler.reshape(content, 10))
+            .assertNext(dataBuffer -> {
+                var str = dataBuffer.toString(UTF_8);
+                assertEquals("halo", str);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    void reshapeDataBuffersWithBiggerBufferSize() {
+        var handler = new S3OsAttachmentHandler();
+        var factory = DefaultDataBufferFactory.sharedInstance;
+        var content = Flux.<DataBuffer>fromIterable(List.of(
+            factory.wrap("ha".getBytes()),
+            factory.wrap("lo".getBytes())
+        ));
+
+        StepVerifier.create(handler.reshape(content, 3))
+            .assertNext(dataBuffer -> {
+                var str = dataBuffer.toString(UTF_8);
+                assertEquals("hal", str);
+            })
+            .assertNext(dataBuffer -> {
+                var str = dataBuffer.toString(UTF_8);
+                assertEquals("o", str);
+            })
+            .verifyComplete();
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

Reshape the DataBuffers into parts of the same size (5MB) except for the last part.

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-sigs/plugin-s3/issues/49

#### Does this PR introduce a user-facing change?

```release-note
保证分片上传时片段大小一致
```
