### PR TITLE
Fallback to default handler for backward compatibility

### DIFF
--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -148,8 +148,8 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
         }
         var objectKey = getObjectKey(attachment);
         if (objectKey == null) {
-            return Mono.error(new IllegalArgumentException(
-                "Cannot obtain object key from attachment " + attachment.getMetadata().getName()));
+            // fallback to default handler for backward compatibility
+            return Mono.empty();
         }
         var properties = getProperties(configMap);
         var objectURL = getObjectURL(properties, objectKey);


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

See https://github.com/halo-sigs/plugin-s3/issues/56 for more.

This PR skips permalink resolution while the object key is missing. So that the default handler will resolve permalink from annotation `storage.halo.run/external-link`

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-sigs/plugin-s3/issues/56

#### Does this PR introduce a user-facing change?

```release-note
解决导入 Halo 1.x 附件后出现“Cannot obtain object key from attachment attachment-xyz”的问题
```
