### PR TITLE
feat: automatic random file renaming optional feature

### DIFF
--- a/src/main/java/run/halo/s3os/FileNameUtils.java
+++ b/src/main/java/run/halo/s3os/FileNameUtils.java
@@ -4,6 +4,9 @@ import com.google.common.io.Files;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public final class FileNameUtils {
 
     private FileNameUtils() {
@@ -15,6 +18,23 @@ public final class FileNameUtils {
         }
         var extPattern = "(?<!^)[.]" + (removeAllExtensions ? ".*" : "[^.]*$");
         return filename.replaceAll(extPattern, "");
+    }
+
+    public static String getExtension(String filename) {
+        String s = null;
+        if (filename == null || filename.isEmpty()) {
+            return s;
+        }
+        String reg = "(?<!^)[.].*";
+        Pattern pattern = Pattern.compile(reg);
+        Matcher matcher = pattern.matcher(filename);
+        while (matcher.find()) {
+            s = matcher.group();
+        }
+        if (s == null || s.isEmpty()) {
+            return "";
+        }
+        return s;
     }
 
     /**

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -391,7 +391,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
                         uploadingFile.remove(uploadState.getUploadingMapKey());
                         uploadState.needRemoveMapKey = false;
                     }
-                    uploadState.randomFileName();
+                    uploadState.randomDuplicateFileName();
                 })
             )
             .onErrorMap(Exceptions::isRetryExhausted,
@@ -471,8 +471,8 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
             this.properties = properties;
             this.originalFileName = fileName;
 
-            fileName = properties.getNeedRandomFilename() ?
-                    UUID.randomUUID().toString().toUpperCase() + FileNameUtils.getExtension(fileName) : fileName;
+            fileName = FileNameUtils.getRandomFilename(fileName,
+                    properties.getRandomStringLength(), properties.getRandomFilenameMode());
 
             this.fileName = fileName;
             this.objectKey = properties.getObjectName(fileName);
@@ -484,8 +484,8 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
             return properties.getBucket() + "/" + objectKey;
         }
 
-        public void randomFileName() {
-            this.fileName = FileNameUtils.randomFileName(originalFileName, 4);
+        public void randomDuplicateFileName() {
+            this.fileName = FileNameUtils.randomFilenameWithString(originalFileName, 4);
             this.objectKey = properties.getObjectName(fileName);
         }
     }

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -470,6 +470,10 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
         public UploadState(S3OsProperties properties, String fileName) {
             this.properties = properties;
             this.originalFileName = fileName;
+
+            fileName = properties.getNeedRandomFilename() ?
+                    UUID.randomUUID().toString().toUpperCase() + FileNameUtils.getExtension(fileName) : fileName;
+
             this.fileName = fileName;
             this.objectKey = properties.getObjectName(fileName);
             this.contentType = MediaTypeFactory.getMediaType(fileName)

--- a/src/main/java/run/halo/s3os/S3OsProperties.java
+++ b/src/main/java/run/halo/s3os/S3OsProperties.java
@@ -75,9 +75,7 @@ class S3OsProperties {
                 this.randomStringLength = length;
             }
         }
-        catch (NumberFormatException e) {
-            this.randomStringLength = 8;
-        }
+        catch (NumberFormatException ignored) { }
     }
 
     public void setRegion(String region) {

--- a/src/main/java/run/halo/s3os/S3OsProperties.java
+++ b/src/main/java/run/halo/s3os/S3OsProperties.java
@@ -23,7 +23,9 @@ class S3OsProperties {
      */
     private String location;
 
-    private Boolean needRandomFilename = false;
+    private String randomFilenameMode = "none";
+
+    private Integer randomStringLength = 8;
 
     private Protocol protocol = Protocol.https;
 
@@ -64,6 +66,18 @@ class S3OsProperties {
             location = "";
         }
         this.location = location;
+    }
+
+    public void setRandomStringLength(String randomStringLength) {  // if you use Integer, it will throw Error.
+        try {
+            int length = Integer.parseInt(randomStringLength);
+            if (length >= 4 && length <= 16) {
+                this.randomStringLength = length;
+            }
+        }
+        catch (NumberFormatException e) {
+            this.randomStringLength = 8;
+        }
     }
 
     public void setRegion(String region) {

--- a/src/main/java/run/halo/s3os/S3OsProperties.java
+++ b/src/main/java/run/halo/s3os/S3OsProperties.java
@@ -23,6 +23,8 @@ class S3OsProperties {
      */
     private String location;
 
+    private Boolean needRandomFilename = false;
+
     private Protocol protocol = Protocol.https;
 
     /**

--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -61,6 +61,16 @@ spec:
           label: 上传目录
           placeholder: 如不填写，则默认上传到根目录
         - $formkit: select
+          name: needRandomFilename
+          label: 上传时自动随机重命名文件
+          options:
+            - label: 是
+              value: true
+            - label: 否
+              value: false
+          validation: required
+          value: false
+        - $formkit: select
           name: protocol
           label: 绑定域名协议
           options:

--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -61,15 +61,28 @@ spec:
           label: 上传目录
           placeholder: 如不填写，则默认上传到根目录
         - $formkit: select
-          name: needRandomFilename
-          label: 上传时自动随机重命名文件
+          name: randomFilenameMode
+          label: 上传时重命名文件方式
           options:
-            - label: 是
-              value: true
-            - label: 否
-              value: false
+            - label: 保留原文件名
+              value: none
+            - label: 使用原文件名 + 随机字符串
+              value: withString
+            - label: 使用日期 + 随机字符串
+              value: dateWithString
+            - label: 使用日期时间 + 随机字符串
+              value: datetimeWithString
+            - label: 使用随机字符串
+              value: string
+            - label: 使用UUID
+              value: uuid
           validation: required
-          value: false
+        - $formkit: number
+          name: randomStringLength
+          label: 随机字符串长度
+          min: 4
+          max: 16
+          placeholder: 仅在重命名文件时需要随机字符串时填写(支持4~16位, 默认为8位)
         - $formkit: select
           name: protocol
           label: 绑定域名协议


### PR DESCRIPTION
图片等文件外链往往需要呈现给用户，由于大部分时候我们都是随手创建的新文件或从别处复制粘贴，文件名会如同`无标题.png`等，上传后按照默认策略也会如同`无标题-qiks.png`等，既不美观也会给用户造成困扰。此功能可以在上传文件时将文件名自动替换为UUID、日期、随机字符串等格式。
```release-note
增加自动随机重命名文件可选功能
```